### PR TITLE
Changed use of SPI Transactions to cooperate with other SPI devices

### DIFF
--- a/src/arduino-rfm/RFM95.cpp
+++ b/src/arduino-rfm/RFM95.cpp
@@ -175,6 +175,9 @@ static unsigned char RFM_Read(unsigned char RFM_Address)
 {
   unsigned char RFM_Data;
 
+  //Add transactions in Read and Write methods
+  SPI.beginTransaction(SPISettings(4000000,MSBFIRST,SPI_MODE0));
+  
   //Set NSS pin low to start SPI communication
   digitalWrite(RFM_pins.CS,LOW);
 
@@ -185,6 +188,9 @@ static unsigned char RFM_Read(unsigned char RFM_Address)
 
   //Set NSS high to end communication
   digitalWrite(RFM_pins.CS,HIGH);
+
+  //End the transaction so that other hardware can use the bus
+  SPI.endTransaction();
 
   #ifdef DEBUG
   Serial.print("SPI Read ADDR: ");
@@ -585,6 +591,9 @@ void RFM_Write(unsigned char RFM_Address, unsigned char RFM_Data)
     Serial.println(RFM_Data, HEX);
   #endif
 
+  //Add transactions in Read and Write methods
+  SPI.beginTransaction(SPISettings(4000000,MSBFIRST,SPI_MODE0));
+
   //Set NSS pin Low to start communication
   digitalWrite(RFM_pins.CS,LOW);
 
@@ -595,6 +604,9 @@ void RFM_Write(unsigned char RFM_Address, unsigned char RFM_Data)
 
   //Set NSS pin High to end communication
   digitalWrite(RFM_pins.CS,HIGH);
+
+  //End the transaction so that other hardware can use the bus
+  SPI.endTransaction();
 }
 
 /*

--- a/src/arduino-rfm/lorawan-arduino-rfm.cpp
+++ b/src/arduino-rfm/lorawan-arduino-rfm.cpp
@@ -137,7 +137,10 @@ bool LoRaWANClass::init(void)
 
     //Initialise the SPI port
     SPI.begin();
-    SPI.beginTransaction(SPISettings(4000000,MSBFIRST,SPI_MODE0));
+    
+    /*** This prevents the use of other SPI devices with different settings ***/
+    //SPI.beginTransaction(SPISettings(4000000,MSBFIRST,SPI_MODE0)); 
+
 
     //Wait until RFM module is started
     delay(50);


### PR DESCRIPTION
Removed SPI.beginTransaction from the LoRaWANClass::init method because it
did not allow for other SPI devices with different settings to use the bus
after init() was called. Instead, SPI.beginTransaction is now called at the
top of the RFM_Write and RFM_Read methods, and SPI.endTransaction is called
at the end of each. This allows other devices to use the bus with their own
transaction settings.

The specific reason for this change is that my application has an SPI 24Bit ADC 
chip that would not function with this library as it was. I thought this would be a useful
change for others so I figured I'd do a pull request.

This change has been running without issue on a device for about 18 hours