### PR TITLE
Change Tx power control

### DIFF
--- a/src/arduino-rfm/RFM95.cpp
+++ b/src/arduino-rfm/RFM95.cpp
@@ -542,22 +542,22 @@ void RFM_Set_Tx_Power(int level, int outputPin)
 
       // High Power +20 dBm Operation (Semtech SX1276/77/78/79 5.4.3.)
       RFM_Write(RFM_REG_PA_DAC, 0x87);
-      setOCP(140);
+      RFM_Set_OCP(140);
     } else {
       if (level < 2) {
         level = 2;
       }
       //Default value PA_HF/LF or +17dBm
       RFM_Write(RFM_REG_PA_DAC, 0x84);
-      setOCP(100);
+      RFM_Set_OCP(100);
     }
 
-    RFM_Write(RFM_REG_PA_CONFIG, PA_BOOST | (level - 2));
+    RFM_Write(RFM_REG_PA_CONFIG, 0x80 | (level - 2));  //PA Boost mask
   }
 }
 
 
-void RFM_set_OCP(uint8_t mA)
+void RFM_Set_OCP(uint8_t mA)
 {
   uint8_t ocpTrim = 27;
 
@@ -567,7 +567,7 @@ void RFM_set_OCP(uint8_t mA)
     ocpTrim = (mA + 30) / 10;
   }
 
-  RFM_Write(REG_OCP, 0x20 | (0x1F & ocpTrim));
+  RFM_Write(RFM_REG_OCP, 0x20 | (0x1F & ocpTrim));
 }
 
 

--- a/src/arduino-rfm/RFM95.cpp
+++ b/src/arduino-rfm/RFM95.cpp
@@ -487,10 +487,9 @@ bool RFM_Init()
   RFM_Switch_Mode(RFM_MODE_STANDBY);
   //Set channel to channel 0
   RFM_Change_Channel(CH0);
-  //PA pin (minimal power)
-  //RFM_Write(0x09,0xF0);
-  //set to 17dbm
-  RFM_Write(RFM_REG_PA_CONFIG,0xF0);
+  //Set default power to maximun on US915 TODO AS/AU/EU config
+  //Set the default output pin as PA_BOOST
+  RFM_Set_Tx_Power(20, PA_BOOST_PIN);
 
   //Switch LNA boost on
   RFM_Write(RFM_REG_LNA,0x23);
@@ -521,7 +520,7 @@ bool RFM_Init()
 
 void RFM_Set_Tx_Power(int level, int outputPin)
 {
-  if (PA_OUTPUT_RFO_PIN == outputPin) {
+  if (RFO_PIN == outputPin) {
     // RFO
     if (level < 0) {
       level = 0;

--- a/src/arduino-rfm/RFM95.h
+++ b/src/arduino-rfm/RFM95.h
@@ -60,6 +60,7 @@ typedef enum {
     RFM_REG_FR_MSB          = 0x06,
     RFM_REG_FR_MID          = 0x07,
     RFM_REG_FR_LSB          = 0x08,
+    RFM_REG_OCP             = 0x0b,
     RFM_REG_PA_CONFIG       = 0x09,
     RFM_REG_LNA             = 0x0C,
     RFM_REG_FIFO_ADDR_PTR   = 0x0D,
@@ -108,6 +109,7 @@ void RFM_Write(unsigned char RFM_Address, unsigned char RFM_Data);
 void RFM_Switch_Mode(unsigned char Mode);
 void RFM_Set_Tx_Power(int level, int outputPin);
 void RFM_Set_OCP(uint8_t mA);
+
 
 #endif
 

--- a/src/arduino-rfm/RFM95.h
+++ b/src/arduino-rfm/RFM95.h
@@ -45,6 +45,9 @@
 
 typedef enum {NO_MESSAGE,NEW_MESSAGE,CRC_OK,MIC_OK,ADDRESS_OK,MESSAGE_DONE,TIMEOUT,WRONG_MESSAGE} message_t;
 
+#define PA_OUTPUT_RFO_PIN          0
+#define PA_OUTPUT_PA_BOOST_PIN     1
+
 /*
 *****************************************************************************************
 * REGISTER DEFINITIONS
@@ -72,7 +75,8 @@ typedef enum {
     RFM_REG_INVERT_IQ2      = 0x3b,
     RFM_REG_SYNC_WORD       = 0x39,
     RFM_REG_DIO_MAPPING1    = 0x40,
-    RFM_REG_DIO_MAPPING2    = 0x41
+    RFM_REG_DIO_MAPPING2    = 0x41,
+    RFM_REG_PA_DAC          = 0x4d
     
     } rfm_register_t;
 
@@ -102,6 +106,8 @@ void RFM_Continuous_Receive(sSettings *LoRa_Settings);
 message_t RFM_Get_Package(sBuffer *RFM_Rx_Package);
 void RFM_Write(unsigned char RFM_Address, unsigned char RFM_Data);
 void RFM_Switch_Mode(unsigned char Mode);
+void RFM_Set_Tx_Power(int level, int outputPin);
+void RFM_Set_OCP(uint8_t mA);
 
 #endif
 

--- a/src/arduino-rfm/Struct.h
+++ b/src/arduino-rfm/Struct.h
@@ -113,6 +113,12 @@ typedef enum {
   MULTI = 20
 } channel_t;
 
+
+typedef enum {
+    RFO_PIN  = 0,
+    PA_BOOST_PIN = 1
+} txPin_t;
+
 typedef enum {
 #if defined(US_915)
     SF10BW125   = 0x00,

--- a/src/arduino-rfm/lorawan-arduino-rfm.cpp
+++ b/src/arduino-rfm/lorawan-arduino-rfm.cpp
@@ -337,7 +337,7 @@ unsigned char LoRaWANClass::getChannel()
 unsigned char LoRaWANClass::getDataRate() {
     return LoRa_Settings.Datarate_Tx;
 }
-void LoRaWANClass::setTxPower(unsigned char power_idx)
+void LoRaWANClass::setTxPower1(unsigned char power_idx)
 {
     unsigned char RFM_Data;
     LoRa_Settings.Transmit_Power = (power_idx > 0x0F) ? 0x0F : power_idx; 

--- a/src/arduino-rfm/lorawan-arduino-rfm.cpp
+++ b/src/arduino-rfm/lorawan-arduino-rfm.cpp
@@ -253,6 +253,11 @@ void LoRaWANClass::setDevAddr(const char *devAddr_in)
     RFM_Command_Status = NO_RFM_COMMAND;
 }
 
+void LoRaWANClass::setTxPower(int level,txPin_t pinTx)
+{
+    RFM_Set_Tx_Power(level, pinTx);
+} 
+
 void LoRaWANClass::setDeviceClass(devclass_t dev_class)
 {
     LoRa_Settings.Mote_Class = (dev_class == CLASS_A)? CLASS_A : CLASS_C;

--- a/src/arduino-rfm/lorawan-arduino-rfm.h
+++ b/src/arduino-rfm/lorawan-arduino-rfm.h
@@ -77,7 +77,8 @@ class LoRaWANClass
         void setChannel(unsigned char channel);
         unsigned char getChannel();
         unsigned char getDataRate();
-        void setTxPower(unsigned char power_idx);
+        void setTxPower1(unsigned char power_idx);
+        void setTxPower(int level,txPin_t pinTx);
         int readData(char *outBuff);
         bool readAck(void);
         void update(void);

--- a/test/testFullfrequency/testFullfrequency.ino
+++ b/test/testFullfrequency/testFullfrequency.ino
@@ -60,7 +60,7 @@ void setup() {
   // Set LoRaWAN Class
   lora.setDeviceClass(CLASS_A);
 
-  lora.setTxPower(15);
+  lora.setTxPower(15,PA_BOOST_PIN);
 
   counter.val = 0;
   _channel = 0; // 0 - 7

--- a/test/testOTAA/testOTAA.ino
+++ b/test/testOTAA/testOTAA.ino
@@ -57,7 +57,7 @@ void setup() {
     return;
   }
   lora.setDeviceClass(CLASS_A);
-  lora.setTxPower(15);
+  lora.setTxPower(15,PA_BOOST_PIN);
   lora.setChannel(CH0);
   lora.setDataRate(SF9BW125);
 


### PR DESCRIPTION
Since the start of the library it has been necessary to add the setTxPower(20);  procedure cause the default configuration is on a really low power configuration 

Which results in my spectrum analyzer as next, only read from the node derctly connected 1.22 dBm 
![data1](https://user-images.githubusercontent.com/15166625/90455751-7c2cb680-e0bc-11ea-90c6-c74e13f7b950.jpeg)

When i use the function setTxPower(20);  at its maximum i see only 15 dBm then i realize that there was some configurationes missing on the Radio 

![data2](https://user-images.githubusercontent.com/15166625/90455845-c31aac00-e0bc-11ea-8821-c88311e22e13.jpeg)

With this pullRequest i added the possibility to choose between RFO and PA_Boost in order to control in what pin the transmission will go, and also added the missing configuration, this resulting on 17.54 dBm which is a big difference.

![data3](https://user-images.githubusercontent.com/15166625/90455912-f3624a80-e0bc-11ea-9860-a3a1cc780b92.jpeg)

We need to take an eye that my measures may not be that accurate cause the loses on my adaptors and the board of the Node.