### PR TITLE
feat: :sparkles: add functionality of retrieving rssi for received signals

### DIFF
--- a/src/arduino-rfm/RFM95.cpp
+++ b/src/arduino-rfm/RFM95.cpp
@@ -815,3 +815,12 @@ void RFM_Switch_Mode(unsigned char Mode)
     RFM_Write(RFM_REG_OP_MODE,Mode);
 }
 
+/*
+*****************************************************************************************
+* Description : Function to retrieve value of the last received packet rssi register
+*****************************************************************************************
+*/
+unsigned char RFM_Get_Rssi()
+{
+  return RFM_Read(RFM_REG_LAST_RSSI);
+}

--- a/src/arduino-rfm/RFM95.h
+++ b/src/arduino-rfm/RFM95.h
@@ -110,6 +110,8 @@ void RFM_Switch_Mode(unsigned char Mode);
 void RFM_Set_Tx_Power(int level, int outputPin);
 void RFM_Set_OCP(unsigned char mA);
 
+unsigned char RFM_Get_Rssi();
+
 
 #endif
 

--- a/src/arduino-rfm/RFM95.h
+++ b/src/arduino-rfm/RFM95.h
@@ -65,6 +65,7 @@ typedef enum {
     RFM_REG_LNA             = 0x0C,
     RFM_REG_FIFO_ADDR_PTR   = 0x0D,
     RFM_REG_IRQ_FLAGS       = 0x12,
+    RFM_REG_LAST_RSSI       = 0x1A,
     RFM_REG_MODEM_CONFIG1   = 0x1D,
     RFM_REG_MODEM_CONFIG2   = 0x1E,
     RFM_REG_SYM_TIMEOUT_LSB = 0x1F,

--- a/src/arduino-rfm/lorawan-arduino-rfm.cpp
+++ b/src/arduino-rfm/lorawan-arduino-rfm.cpp
@@ -257,6 +257,12 @@ void LoRaWANClass::setTxPower(int level,txPin_t pinTx)
     RFM_Set_Tx_Power(level, pinTx);
 } 
 
+int LoRaWANClass::getRssi()
+{
+    // return rssi value in dBm - convertion according to sx1276 datasheet
+    return -157 + RFM_Get_Rssi();
+}
+
 void LoRaWANClass::setDeviceClass(devclass_t dev_class)
 {
     LoRa_Settings.Mote_Class = (dev_class == CLASS_A)? CLASS_A : CLASS_C;

--- a/src/arduino-rfm/lorawan-arduino-rfm.h
+++ b/src/arduino-rfm/lorawan-arduino-rfm.h
@@ -79,6 +79,7 @@ class LoRaWANClass
         unsigned char getDataRate();
         void setTxPower1(unsigned char power_idx);
         void setTxPower(int level,txPin_t pinTx);
+        int getRssi();
         int readData(char *outBuff);
         bool readAck(void);
         void update(void);


### PR DESCRIPTION
Just a small feature that some might find useful. Uses underlying RFM95 functionality and exposes it through lorawanclass.