### PR TITLE
added sleep and wakeUp method

### DIFF
--- a/API.md
+++ b/API.md
@@ -16,6 +16,42 @@ void setup() {
 }
 ```
 
+### LoRa module sleep
+Put LoRa/LoRaWAN module to sleep.
+
+#### Syntax
+```c
+  void sleep(void);
+```
+
+#### Example
+```c
+void loop() {
+  ...
+  // Put module to sleep
+  lora.sleep();
+  ...
+}
+```
+
+### LoRa module sleep
+Wake LoRa/LoRaWAN module.
+
+#### Syntax
+```c
+  void wakeUp(void);
+```
+
+#### Example
+```c
+void loop() {
+  ...
+  // Wake up module
+  lora.wakeUp();
+  ...
+}
+```
+
 ### Setup Authentication Keys for ABP activation
 Setup authentication keys for your LoRaWAN device, including device address.
 

--- a/src/arduino-rfm/Config.h
+++ b/src/arduino-rfm/Config.h
@@ -1,41 +1,41 @@
-//Uncomment for debug 
+//Uncomment for debug
 //#define DEBUG
 
 // Define max payload size used for this node
-#define MAX_UPLINK_PAYLOAD_SIZE    220  
-#define MAX_DOWNLINK_PAYLOAD_SIZE   220
+#define MAX_UPLINK_PAYLOAD_SIZE 220
+#define MAX_DOWNLINK_PAYLOAD_SIZE 220
 
 #if !defined(AS_923) && !defined(EU_868) && !defined(US_915) && !defined(AU_915)
 
 //LoRaWAN freq band
 //#define AS_923
-//#define EU_868
-#define US_915
+#define EU_868
+//#define US_915
 //#define AU_915
 
 #ifdef US_915
-    //Select the subband youre working on
-    // make sure your gateway is working in one of these bands
-    #define SUBND_0     // 902.3 - 903.7 Mhz
-    //#define SUBND_1     // 903.9 - 905.3 Mhz TTN
-    //#define SUBND_2     // 905.5 - 906.9 Mhz
-    //#define SUBND_3     // 907.1 - 908.5 Mhz
-    //#define SUBND_4     // 908.7 - 910.1 Mhz
-    //#define SUBND_5     // 910.3 - 911.7 Mhz
-    //#define SUBND_6     // 911.9 - 913.3 Mhz
-    //#define SUBND_7     // 913.5 - 914.9 Mhz
+//Select the subband youre working on
+// make sure your gateway is working in one of these bands
+#define SUBND_0 // 902.3 - 903.7 Mhz
+//#define SUBND_1     // 903.9 - 905.3 Mhz TTN
+//#define SUBND_2     // 905.5 - 906.9 Mhz
+//#define SUBND_3     // 907.1 - 908.5 Mhz
+//#define SUBND_4     // 908.7 - 910.1 Mhz
+//#define SUBND_5     // 910.3 - 911.7 Mhz
+//#define SUBND_6     // 911.9 - 913.3 Mhz
+//#define SUBND_7     // 913.5 - 914.9 Mhz
 #endif
 
 #ifdef AU_915
-    //Select the subband youre working on
-    // make sure your gateway is working in one of these bands
-    #define SUBND_0     // 915.2 - 916.6 Mhz
-    //#define SUBND_1     // 916.8 - 918.2 Mhz
-    //#define SUBND_2     // 918.4 - 919.8 Mhz
-    //#define SUBND_3     // 920.0 - 921.4 Mhz
-    //#define SUBND_4     // 921.6 - 923.0 Mhz
-    //#define SUBND_5     // 923.2 - 924.6 Mhz
-    //#define SUBND_6     // 924.8 - 926.2 Mhz
-    //#define SUBND_7     // 926.4 - 927.8 Mhz
+//Select the subband youre working on
+// make sure your gateway is working in one of these bands
+#define SUBND_0 // 915.2 - 916.6 Mhz
+//#define SUBND_1     // 916.8 - 918.2 Mhz
+//#define SUBND_2     // 918.4 - 919.8 Mhz
+//#define SUBND_3     // 920.0 - 921.4 Mhz
+//#define SUBND_4     // 921.6 - 923.0 Mhz
+//#define SUBND_5     // 923.2 - 924.6 Mhz
+//#define SUBND_6     // 924.8 - 926.2 Mhz
+//#define SUBND_7     // 926.4 - 927.8 Mhz
 #endif
 #endif

--- a/src/arduino-rfm/lorawan-arduino-rfm.cpp
+++ b/src/arduino-rfm/lorawan-arduino-rfm.cpp
@@ -28,18 +28,15 @@
     Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 
-
 #include "lorawan-arduino-rfm.h"
 #include "Conversions.h"
 
 LoRaWANClass::LoRaWANClass()
 {
-
 }
 
 LoRaWANClass::~LoRaWANClass()
 {
-
 }
 
 bool LoRaWANClass::init(void)
@@ -61,7 +58,7 @@ bool LoRaWANClass::init(void)
     memset(Address_Tx, 0x00, 4);
     memset(NwkSKey, 0x00, 16);
     memset(AppSKey, 0x00, 16);
-    
+
     Frame_Counter_Tx = 0x0000;
     Session_Data.NwkSKey = NwkSKey;
     Session_Data.AppSKey = AppSKey;
@@ -82,31 +79,31 @@ bool LoRaWANClass::init(void)
     OTAA_Data.DevNonce = DevNonce;
     OTAA_Data.AppNonce = AppNonce;
     OTAA_Data.NetID = NetID;
-    
+
     // Device Class
     LoRa_Settings.Mote_Class = 0x00; //0x00 is type A, 0x01 is type C
-    
+
     // Rx
 #if defined(AS_923)
-    LoRa_Settings.Datarate_Rx = 0x02;   //set to SF10 BW 125 kHz
+    LoRa_Settings.Datarate_Rx = 0x02; //set to SF10 BW 125 kHz
 #elif defined(EU_868)
-    LoRa_Settings.Datarate_Rx = 0x03;   //set to SF9 BW 125 kHz
+    LoRa_Settings.Datarate_Rx = 0x03;                //set to SF9 BW 125 kHz
 #else //US_915 or AU_915
-    LoRa_Settings.Datarate_Rx = 0x0C;   //set to SF8 BW 500 kHz
+    LoRa_Settings.Datarate_Rx = 0x0C;                //set to SF8 BW 500 kHz
 #endif
-    LoRa_Settings.Channel_Rx = 0x08;    // set to recv channel
+    LoRa_Settings.Channel_Rx = 0x08; // set to recv channel
 
     // Tx
 #if defined(US_915)
-    LoRa_Settings.Datarate_Tx = drate_common = 0x02;   //set to SF7 BW 125 kHz
+    LoRa_Settings.Datarate_Tx = drate_common = 0x02; //set to SF7 BW 125 kHz
 #elif defined(AU_915)
-    LoRa_Settings.Datarate_Tx = drate_common = 0x02;   //set to SF7 BW 125 kHz
+    LoRa_Settings.Datarate_Tx = drate_common = 0x02; //set to SF7 BW 125 kHz
 #else
-    LoRa_Settings.Datarate_Tx = drate_common = 0x00;   //set to SF12 BW 125 kHz
+    LoRa_Settings.Datarate_Tx = drate_common = 0x00; //set to SF12 BW 125 kHz
 #endif
-    LoRa_Settings.Channel_Tx = 0x00;    // set to channel 0
+    LoRa_Settings.Channel_Tx = 0x00; // set to channel 0
 
-    LoRa_Settings.Confirm = 0x00; //0x00 unconfirmed, 0x01 confirmed
+    LoRa_Settings.Confirm = 0x00;         //0x00 unconfirmed, 0x01 confirmed
     LoRa_Settings.Channel_Hopping = 0x00; //0x00 no channel hopping, 0x01 channel hopping
 
     // Initialise buffer for data to transmit
@@ -120,48 +117,49 @@ bool LoRaWANClass::init(void)
     Message_Rx.Direction = 0x01; //Set down direction for Rx message
 
     //Initialize I/O pins
-    pinMode(RFM_pins.DIO0,INPUT);
-    pinMode(RFM_pins.DIO1,INPUT);
-    #ifdef BOARD_DRAGINO_SHIELD
-    pinMode(RFM_pins.DIO5,INPUT);
-    #endif
-    pinMode(RFM_pins.DIO2,INPUT);
-    pinMode(RFM_pins.CS,OUTPUT);
-    pinMode(RFM_pins.RST,OUTPUT);
-    
-    digitalWrite(RFM_pins.CS,HIGH);
-    
+    pinMode(RFM_pins.DIO0, INPUT);
+    pinMode(RFM_pins.DIO1, INPUT);
+#ifdef BOARD_DRAGINO_SHIELD
+    pinMode(RFM_pins.DIO5, INPUT);
+#endif
+    pinMode(RFM_pins.DIO2, INPUT);
+    pinMode(RFM_pins.CS, OUTPUT);
+    pinMode(RFM_pins.RST, OUTPUT);
+
+    digitalWrite(RFM_pins.CS, HIGH);
+
     // Reset
-    digitalWrite(RFM_pins.RST,HIGH);
+    digitalWrite(RFM_pins.RST, HIGH);
     delay(10);
-    digitalWrite(RFM_pins.RST,LOW);
+    digitalWrite(RFM_pins.RST, LOW);
     delay(10);
-    digitalWrite(RFM_pins.RST,HIGH);
+    digitalWrite(RFM_pins.RST, HIGH);
 
     //Initialise the SPI port
     SPI.begin();
-    
-    /*** This prevents the use of other SPI devices with different settings ***/
-    //SPI.beginTransaction(SPISettings(4000000,MSBFIRST,SPI_MODE0)); 
 
+    /*** This prevents the use of other SPI devices with different settings ***/
+    //SPI.beginTransaction(SPISettings(4000000,MSBFIRST,SPI_MODE0));
 
     //Wait until RFM module is started
     delay(50);
-    
+
     //Initialize RFM module
-    if(!RFM_Init()){
-    return 0;
+    if (!RFM_Init())
+    {
+        return 0;
     }
     return 1;
 }
 
 bool LoRaWANClass::join(void)
-{    
+{
     bool join_status;
     const unsigned long timeout = 6000;
-    unsigned long prev_millis;    
+    unsigned long prev_millis;
 
-    if (currentChannel == MULTI) {
+    if (currentChannel == MULTI)
+    {
         randomChannel();
     }
     // join request
@@ -169,18 +167,31 @@ bool LoRaWANClass::join(void)
     // delay(900);
     // loop for <timeout> wait for join accept
     prev_millis = millis();
-    do {
+    do
+    {
         join_status = LORA_join_Accept(&Buffer_Rx, &Session_Data, &OTAA_Data, &Message_Rx, &LoRa_Settings);
 
-    }while ((millis() - prev_millis) < timeout && !join_status);
+    } while ((millis() - prev_millis) < timeout && !join_status);
 
     return join_status;
 }
 
+void LoRaWANClass::sleep(void)
+{
+    //Switch RFM to sleep
+    //DON'T USE Switch mode function
+    RFM_Write(RFM_REG_OP_MODE, RFM_MODE_SLEEP);
+}
+
+void LoRaWANClass::wakeUp(void)
+{
+    RFM_Switch_Mode(RFM_MODE_STANDBY);
+}
+
 void LoRaWANClass::setDevEUI(const char *devEUI_in)
 {
-    for(byte i = 0; i < 8; ++i)
-        DevEUI[i] = ASCII2Hex(devEUI_in[i*2],devEUI_in[(i*2) + 1]);
+    for (byte i = 0; i < 8; ++i)
+        DevEUI[i] = ASCII2Hex(devEUI_in[i * 2], devEUI_in[(i * 2) + 1]);
     //Reset frame counter
     Frame_Counter_Tx = 0x0000;
 
@@ -190,8 +201,8 @@ void LoRaWANClass::setDevEUI(const char *devEUI_in)
 
 void LoRaWANClass::setAppEUI(const char *appEUI_in)
 {
-    for(byte i = 0; i < 8; ++i)
-        AppEUI[i] = ASCII2Hex(appEUI_in[i*2],appEUI_in[(i*2) + 1]);
+    for (byte i = 0; i < 8; ++i)
+        AppEUI[i] = ASCII2Hex(appEUI_in[i * 2], appEUI_in[(i * 2) + 1]);
     //Reset frame counter
     Frame_Counter_Tx = 0x0000;
 
@@ -201,20 +212,19 @@ void LoRaWANClass::setAppEUI(const char *appEUI_in)
 
 void LoRaWANClass::setAppKey(const char *appKey_in)
 {
-    for(byte i = 0; i < 16; ++i)
-        AppKey[i] = ASCII2Hex(appKey_in[i*2],appKey_in[(i*2) + 1]);
+    for (byte i = 0; i < 16; ++i)
+        AppKey[i] = ASCII2Hex(appKey_in[i * 2], appKey_in[(i * 2) + 1]);
     //Reset frame counter
     Frame_Counter_Tx = 0x0000;
 
     //Reset RFM command status
     RFM_Command_Status = NO_RFM_COMMAND;
-
 }
 
 void LoRaWANClass::setNwkSKey(const char *NwkKey_in)
 {
     for (uint8_t i = 0; i < 16; ++i)
-        NwkSKey[i] = ASCII2Hex(NwkKey_in[i*2],NwkKey_in[(i*2)+1]);
+        NwkSKey[i] = ASCII2Hex(NwkKey_in[i * 2], NwkKey_in[(i * 2) + 1]);
 
     //Reset frame counter
     Frame_Counter_Tx = 0x0000;
@@ -226,8 +236,8 @@ void LoRaWANClass::setNwkSKey(const char *NwkKey_in)
 void LoRaWANClass::setAppSKey(const char *ApskKey_in)
 {
     for (uint8_t i = 0; i < 16; ++i)
-        AppSKey[i] = ASCII2Hex(ApskKey_in[i*2],ApskKey_in[(i*2)+1]);
-    
+        AppSKey[i] = ASCII2Hex(ApskKey_in[i * 2], ApskKey_in[(i * 2) + 1]);
+
     //Reset frame counter
     Frame_Counter_Tx = 0x0000;
 
@@ -240,10 +250,10 @@ void LoRaWANClass::setDevAddr(const char *devAddr_in)
     memset(Session_Data.DevAddr, 0x30, sizeof(Session_Data.DevAddr));
 
     //Check if it is a set command and there is enough data sent
-    Address_Tx[0] = ASCII2Hex(devAddr_in[0],devAddr_in[1]);
-    Address_Tx[1] = ASCII2Hex(devAddr_in[2],devAddr_in[3]);
-    Address_Tx[2] = ASCII2Hex(devAddr_in[4],devAddr_in[5]);
-    Address_Tx[3] = ASCII2Hex(devAddr_in[6],devAddr_in[7]);
+    Address_Tx[0] = ASCII2Hex(devAddr_in[0], devAddr_in[1]);
+    Address_Tx[1] = ASCII2Hex(devAddr_in[2], devAddr_in[3]);
+    Address_Tx[2] = ASCII2Hex(devAddr_in[4], devAddr_in[5]);
+    Address_Tx[3] = ASCII2Hex(devAddr_in[6], devAddr_in[7]);
 
     //Reset frame counter
     Frame_Counter_Tx = 0x0000;
@@ -252,10 +262,10 @@ void LoRaWANClass::setDevAddr(const char *devAddr_in)
     RFM_Command_Status = NO_RFM_COMMAND;
 }
 
-void LoRaWANClass::setTxPower(int level,txPin_t pinTx)
+void LoRaWANClass::setTxPower(int level, txPin_t pinTx)
 {
     RFM_Set_Tx_Power(level, pinTx);
-} 
+}
 
 int LoRaWANClass::getRssi()
 {
@@ -265,11 +275,14 @@ int LoRaWANClass::getRssi()
 
 void LoRaWANClass::setDeviceClass(devclass_t dev_class)
 {
-    LoRa_Settings.Mote_Class = (dev_class == CLASS_A)? CLASS_A : CLASS_C;
+    LoRa_Settings.Mote_Class = (dev_class == CLASS_A) ? CLASS_A : CLASS_C;
 
-    if (LoRa_Settings.Mote_Class == CLASS_A) {
+    if (LoRa_Settings.Mote_Class == CLASS_A)
+    {
         RFM_Switch_Mode(RFM_MODE_STANDBY);
-    } else {
+    }
+    else
+    {
         RFM_Continuous_Receive(&LoRa_Settings);
     }
 
@@ -279,39 +292,44 @@ void LoRaWANClass::setDeviceClass(devclass_t dev_class)
 
 void LoRaWANClass::sendUplink(char *data, unsigned int len, unsigned char confirm, unsigned char mport)
 {
-    if (currentChannel == MULTI) {
+    if (currentChannel == MULTI)
+    {
         randomChannel();
     }
-    LoRa_Settings.Confirm = (confirm == 0) ? 0 : 1;	
-    if (mport == 0) mport = 1;
-    if (mport > 223) mport = 1;	
+    LoRa_Settings.Confirm = (confirm == 0) ? 0 : 1;
+    if (mport == 0)
+        mport = 1;
+    if (mport > 223)
+        mport = 1;
     LoRa_Settings.Mport = mport;
     //Set new command for RFM
-    RFM_Command_Status = NEW_RFM_COMMAND;   
+    RFM_Command_Status = NEW_RFM_COMMAND;
     Buffer_Tx.Counter = len;
-    memcpy(Buffer_Tx.Data,data,len);
+    memcpy(Buffer_Tx.Data, data, len);
 }
 
 void LoRaWANClass::setDataRate(unsigned char data_rate)
 {
     drate_common = data_rate;
 #if defined(US_915)
-  if(drate_common <= 0x04){
-    LoRa_Settings.Datarate_Tx = drate_common;
-    LoRa_Settings.Datarate_Rx = data_rate + 0x0A;
-  }
+    if (drate_common <= 0x04)
+    {
+        LoRa_Settings.Datarate_Tx = drate_common;
+        LoRa_Settings.Datarate_Rx = data_rate + 0x0A;
+    }
 #elif defined(AU_915)
-  if(drate_common <= 0x04){
-    LoRa_Settings.Datarate_Tx = drate_common;
-    LoRa_Settings.Datarate_Rx = data_rate + 0x0A;
-  }
+    if (drate_common <= 0x04)
+    {
+        LoRa_Settings.Datarate_Tx = drate_common;
+        LoRa_Settings.Datarate_Rx = data_rate + 0x0A;
+    }
 #else
-  //Check if the value is oke
-  if(drate_common <= 0x06)
-  {
-    LoRa_Settings.Datarate_Tx = drate_common;
-    LoRa_Settings.Datarate_Rx = drate_common;
-  }
+    //Check if the value is oke
+    if (drate_common <= 0x06)
+    {
+        LoRa_Settings.Datarate_Tx = drate_common;
+        LoRa_Settings.Datarate_Rx = drate_common;
+    }
 
 #endif
     RFM_Command_Status = NO_RFM_COMMAND;
@@ -319,17 +337,20 @@ void LoRaWANClass::setDataRate(unsigned char data_rate)
 
 void LoRaWANClass::setChannel(unsigned char channel)
 {
-    if (channel <= 7) {
+    if (channel <= 7)
+    {
         currentChannel = channel;
         LoRa_Settings.Channel_Tx = channel;
 #ifdef US_915
-        LoRa_Settings.Channel_Rx = channel + 0x08;  
+        LoRa_Settings.Channel_Rx = channel + 0x08;
 #elif defined(AU_915)
-        LoRa_Settings.Channel_Rx = channel + 0x08;  
-#elif defined(EU_868)  
+        LoRa_Settings.Channel_Rx = channel + 0x08;
+#elif defined(EU_868)
         LoRa_Settings.Channel_Rx = channel;
 #endif
-    } else if (channel == MULTI) {
+    }
+    else if (channel == MULTI)
+    {
         currentChannel = MULTI;
     }
 }
@@ -339,13 +360,14 @@ unsigned char LoRaWANClass::getChannel()
     return LoRa_Settings.Channel_Tx;
 }
 
-unsigned char LoRaWANClass::getDataRate() {
+unsigned char LoRaWANClass::getDataRate()
+{
     return LoRa_Settings.Datarate_Tx;
 }
 void LoRaWANClass::setTxPower1(unsigned char power_idx)
 {
     unsigned char RFM_Data;
-    LoRa_Settings.Transmit_Power = (power_idx > 0x0F) ? 0x0F : power_idx; 
+    LoRa_Settings.Transmit_Power = (power_idx > 0x0F) ? 0x0F : power_idx;
     RFM_Data = LoRa_Settings.Transmit_Power + 0xF0;
     RFM_Write(RFM_REG_PA_CONFIG, RFM_Data);
 }
@@ -354,15 +376,15 @@ int LoRaWANClass::readData(char *outBuff)
 {
     int res = 0;
     //If there is new data
-    if(Rx_Status == NEW_RX)
+    if (Rx_Status == NEW_RX)
     {
         res = Buffer_Rx.Counter;
         memset(outBuff, 0x00, res + 1);
         memcpy(outBuff, Buffer_Rx.Data, res);
-        
+
         // Clear Buffer counter
         Buffer_Rx.Counter = 0x00;
-        
+
         Rx_Status = NO_RX;
     }
 
@@ -378,8 +400,8 @@ bool LoRaWANClass::readAck(void)
 {
     if (Ack_Status == NEW_ACK)
     {
-      Ack_Status = NO_ACK;
-      return true;
+        Ack_Status = NO_ACK;
+        return true;
     }
     return false;
 }
@@ -387,73 +409,76 @@ bool LoRaWANClass::readAck(void)
 void LoRaWANClass::update(void)
 {
     //Type A mote transmit receive cycle
-    if((RFM_Command_Status == NEW_RFM_COMMAND || RFM_Command_Status == JOIN) && LoRa_Settings.Mote_Class == CLASS_A)
+    if ((RFM_Command_Status == NEW_RFM_COMMAND || RFM_Command_Status == JOIN) && LoRa_Settings.Mote_Class == CLASS_A)
     {
-      //LoRaWAN TX/RX cycle
-      LORA_Cycle(&Buffer_Tx, &Buffer_Rx, &RFM_Command_Status, &Session_Data, &OTAA_Data, &Message_Rx, &LoRa_Settings);
+        //LoRaWAN TX/RX cycle
+        LORA_Cycle(&Buffer_Tx, &Buffer_Rx, &RFM_Command_Status, &Session_Data, &OTAA_Data, &Message_Rx, &LoRa_Settings);
 
-      if ((Message_Rx.Frame_Control & 0x20) > 0)
-        Ack_Status = NEW_ACK;
+        if ((Message_Rx.Frame_Control & 0x20) > 0)
+            Ack_Status = NEW_ACK;
 
-      if(Buffer_Rx.Counter != 0x00)
-      {
-        Rx_Status = NEW_RX;
-      }
-      
-      RFM_Command_Status = NO_RFM_COMMAND;
+        if (Buffer_Rx.Counter != 0x00)
+        {
+            Rx_Status = NEW_RX;
+        }
+
+        RFM_Command_Status = NO_RFM_COMMAND;
     }
 
     //Type C mote transmit and receive handling
-    if(LoRa_Settings.Mote_Class == CLASS_C)
+    if (LoRa_Settings.Mote_Class == CLASS_C)
     {
-       //Transmit
-      if(RFM_Command_Status == NEW_RFM_COMMAND){     
-        //LoRaWAN TX/RX cycle
-        LORA_Cycle(&Buffer_Tx, &Buffer_Rx, &RFM_Command_Status, &Session_Data, &OTAA_Data, &Message_Rx, &LoRa_Settings);
-        if(Buffer_Rx.Counter != 0x00){
-            Rx_Status = NEW_RX;
+        //Transmit
+        if (RFM_Command_Status == NEW_RFM_COMMAND)
+        {
+            //LoRaWAN TX/RX cycle
+            LORA_Cycle(&Buffer_Tx, &Buffer_Rx, &RFM_Command_Status, &Session_Data, &OTAA_Data, &Message_Rx, &LoRa_Settings);
+            if (Buffer_Rx.Counter != 0x00)
+            {
+                Rx_Status = NEW_RX;
+            }
+            RFM_Command_Status = NO_RFM_COMMAND;
+        }
+
+        //Receive
+        if (digitalRead(RFM_pins.DIO0) == HIGH)
+        {
+            LORA_Receive_Data(&Buffer_Rx, &Session_Data, &OTAA_Data, &Message_Rx, &LoRa_Settings);
+            if (Buffer_Rx.Counter != 0x00)
+            {
+                Rx_Status = NEW_RX;
+            }
         }
         RFM_Command_Status = NO_RFM_COMMAND;
-      }
-
-      //Receive
-      if(digitalRead(RFM_pins.DIO0) == HIGH){
-        LORA_Receive_Data(&Buffer_Rx, &Session_Data, &OTAA_Data, &Message_Rx, &LoRa_Settings);
-        if(Buffer_Rx.Counter != 0x00){
-            Rx_Status = NEW_RX;
-        }
-      }
-      RFM_Command_Status = NO_RFM_COMMAND;
     }
-
 }
 
 void LoRaWANClass::randomChannel()
 {
     unsigned char freq_idx;
 #ifdef AS_923
-    freq_idx = random(0,9);
+    freq_idx = random(0, 9);
     // limit drate, ch 8 -> sf7bw250
-    LoRa_Settings.Datarate_Tx = freq_idx == 0x08? 0x06 : drate_common;
-#elif defined(EU_868)    
-    freq_idx = random(0,7);
-    LoRa_Settings.Channel_Rx=freq_idx;      // same rx and tx channel 
+    LoRa_Settings.Datarate_Tx = freq_idx == 0x08 ? 0x06 : drate_common;
+#elif defined(EU_868)
+    freq_idx = random(0, 7);
+    LoRa_Settings.Channel_Rx = freq_idx; // same rx and tx channel
 #else // US_915 or AU_915
-    freq_idx = random(0,8);
+    freq_idx = random(0, 8);
     LoRa_Settings.Channel_Rx = freq_idx + 0x08;
 #endif
     LoRa_Settings.Channel_Tx = freq_idx;
 }
 
-unsigned int LoRaWANClass::getFrameCounter() {
+unsigned int LoRaWANClass::getFrameCounter()
+{
     return Frame_Counter_Tx;
 }
 
-void LoRaWANClass::setFrameCounter(unsigned int FrameCounter) {
+void LoRaWANClass::setFrameCounter(unsigned int FrameCounter)
+{
     Frame_Counter_Tx = FrameCounter;
 }
 
-
-
-// define lora objet 
+// define lora objet
 LoRaWANClass lora;

--- a/src/arduino-rfm/lorawan-arduino-rfm.h
+++ b/src/arduino-rfm/lorawan-arduino-rfm.h
@@ -46,7 +46,6 @@
 ********************************************************************************************
 */
 
-
 #define LORAWAN_VERSION "1.0.0"
 /*
 *****************************************************************************************
@@ -56,83 +55,84 @@
 
 class LoRaWANClass
 {
-    public:
+public:
+    LoRaWANClass();
+    ~LoRaWANClass();
 
-        LoRaWANClass();
-        ~LoRaWANClass();
-        
-        bool init(void);
-        bool join(void);
-        void setDeviceClass(devclass_t dev_class);
-        // OTAA credentials
-        void setDevEUI(const char *devEUI_in);
-        void setAppEUI(const char *appEUI_in);
-        void setAppKey(const char *appKey_in);
-        // ABP credentials
-        void setNwkSKey(const char *NwkKey_in);
-        void setAppSKey(const char *ApskKey_in);
-        void setDevAddr(const char *devAddr_in);
-        void sendUplink(char *data, unsigned int len, unsigned char confirm, unsigned char mport);
-        void setDataRate(unsigned char data_rate);
-        void setChannel(unsigned char channel);
-        unsigned char getChannel();
-        unsigned char getDataRate();
-        void setTxPower1(unsigned char power_idx);
-        void setTxPower(int level,txPin_t pinTx);
-        int getRssi();
-        int readData(char *outBuff);
-        bool readAck(void);
-        void update(void);
+    bool init(void);
+    bool join(void);
+    void sleep(void);
+    void wakeUp(void);
+    void setDeviceClass(devclass_t dev_class);
+    // OTAA credentials
+    void setDevEUI(const char *devEUI_in);
+    void setAppEUI(const char *appEUI_in);
+    void setAppKey(const char *appKey_in);
+    // ABP credentials
+    void setNwkSKey(const char *NwkKey_in);
+    void setAppSKey(const char *ApskKey_in);
+    void setDevAddr(const char *devAddr_in);
+    void sendUplink(char *data, unsigned int len, unsigned char confirm, unsigned char mport);
+    void setDataRate(unsigned char data_rate);
+    void setChannel(unsigned char channel);
+    unsigned char getChannel();
+    unsigned char getDataRate();
+    void setTxPower1(unsigned char power_idx);
+    void setTxPower(int level, txPin_t pinTx);
+    int getRssi();
+    int readData(char *outBuff);
+    bool readAck(void);
+    void update(void);
 
-        // frame counter
-        unsigned int getFrameCounter();
-        void setFrameCounter(unsigned int FrameCounter);
+    // frame counter
+    unsigned int getFrameCounter();
+    void setFrameCounter(unsigned int FrameCounter);
 
-    private:
-        void randomChannel();
+private:
+    void randomChannel();
 
-    private:        
-        // Messages
-        unsigned char Data_Tx[MAX_UPLINK_PAYLOAD_SIZE];
-        sBuffer Buffer_Tx;
-        unsigned char Data_Rx[MAX_DOWNLINK_PAYLOAD_SIZE];
-        sBuffer Buffer_Rx;
-        sLoRa_Message Message_Rx;
+private:
+    // Messages
+    unsigned char Data_Tx[MAX_UPLINK_PAYLOAD_SIZE];
+    sBuffer Buffer_Tx;
+    unsigned char Data_Rx[MAX_DOWNLINK_PAYLOAD_SIZE];
+    sBuffer Buffer_Rx;
+    sLoRa_Message Message_Rx;
 
-        // Declare ABP session
-        unsigned char Address_Tx[4];
-        unsigned char NwkSKey[16];
-        unsigned char AppSKey[16];
-        unsigned int Frame_Counter_Tx;
-        sLoRa_Session Session_Data;
+    // Declare ABP session
+    unsigned char Address_Tx[4];
+    unsigned char NwkSKey[16];
+    unsigned char AppSKey[16];
+    unsigned int Frame_Counter_Tx;
+    sLoRa_Session Session_Data;
 
-        // Declare OTAA data struct
-        unsigned char DevEUI[8];
-        unsigned char AppEUI[8];
-        unsigned char AppKey[16];
-        unsigned char DevNonce[2];
-        unsigned char AppNonce[3];
-        unsigned char NetID[3];
-        sLoRa_OTAA OTAA_Data;
+    // Declare OTAA data struct
+    unsigned char DevEUI[8];
+    unsigned char AppEUI[8];
+    unsigned char AppKey[16];
+    unsigned char DevNonce[2];
+    unsigned char AppNonce[3];
+    unsigned char NetID[3];
+    sLoRa_OTAA OTAA_Data;
 
-        // Declare LoRA settings struct
-        sSettings LoRa_Settings;
-        sRFM_pins LoRa_Pins;
+    // Declare LoRA settings struct
+    sSettings LoRa_Settings;
+    sRFM_pins LoRa_Pins;
 
-        unsigned char drate_common;
+    unsigned char drate_common;
 
-        // Lora Setting Class
-        devclass_t dev_class;
+    // Lora Setting Class
+    devclass_t dev_class;
 
-        // channel mode
-        unsigned char currentChannel;
+    // channel mode
+    unsigned char currentChannel;
 
-        // UART
-        RFM_command_t RFM_Command_Status;
-        rx_t Rx_Status;
+    // UART
+    RFM_command_t RFM_Command_Status;
+    rx_t Rx_Status;
 
-        // ACK reception
-        ack_t Ack_Status;
+    // ACK reception
+    ack_t Ack_Status;
 };
 
 #endif


### PR DESCRIPTION
Hi,

i needed low power mode and added methods to the LoRaWANClass. As the OTAA credentials and session keys are stored in RAM, the session ist automatically restored when waking up the module. 

I put the module to sleep with:

`RFM_Write(RFM_REG_OP_MODE, RFM_MODE_SLEEP);`

and wake it up with

`RFM_Switch_Mode(RFM_MODE_STANDBY);`

Is it that simple, or did i forgot something? I tested class A with OTAA. It is working in my setup, but maybe someone can confirm it's working on their setup too? I use an Atmega4808 as MCU.

Best regards and thank you for this lightweight and simple library!